### PR TITLE
Fix: Skip integration tests when API_TOKEN is not set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -51,5 +51,8 @@ module.exports = {
   testTimeout: 30000,
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-  unmockedModulePathPatterns: []
+  unmockedModulePathPatterns: [],
+
+  // Skip integration tests when no API_TOKEN (e.g. Dependabot PRs)
+  testPathIgnorePatterns: process.env.API_TOKEN ? [] : ['/features/']
 };


### PR DESCRIPTION
Ignore `/features/` test path in Jest config when `API_TOKEN` env var is missing, preventing Dependabot PRs from failing on integration tests that need real credentials.