### PR TITLE
Fix: Correct testPathIgnorePatterns regex for feature test skipping

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -54,5 +54,5 @@ module.exports = {
   unmockedModulePathPatterns: [],
 
   // Skip integration tests when no API_TOKEN (e.g. Dependabot PRs)
-  testPathIgnorePatterns: process.env.API_TOKEN ? [] : ['/features/']
+  testPathIgnorePatterns: process.env.API_TOKEN ? [] : ['features/']
 };


### PR DESCRIPTION
Jest matches `testPathIgnorePatterns` against root-relative paths (e.g. `features/upload-and-download-file.feature.js`), so the leading `/` in `/features/` caused the pattern to never match. Changed to `features/`.