### PR TITLE
Fix: Trigger publish workflow on release published, not created

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
GitHub sends a `published` event when a draft release is published, which is not covered by the `created` trigger. `published` covers both draft publishing and direct release creation.

Closes #326